### PR TITLE
Sales UI Improvements + Readme + Fix for 0 BI Dashboards input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,21 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+![CircleCI](https://img.shields.io/circleci/build/github/hashmapinc/snowflake-estimator/main?label=CircleCI%20Master%20Build)
 
-## Available Scripts
+# Snowflake Estimator
+Welcome to the Snowflake Estimator project! 
 
-In the project directory, you can run:
+You can access a live version of the tool at https://estimator.snowflakeinspector.com
 
-### `npm start`
+## How to run locally for development
+To build the project, ensure you have `npm` installed and do the following:
+- Run `npm i` to install dependencies
+- Run `npm start` and visit http://localhost:3000
 
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+## How to build for production:
+To build the project, ensure you have `npm` installed and do the following:
+- run `npm i` to install dependencies
+- run `npm run build` to build the static website. The files will show up in `build/`
 
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
+## Reach out + Feedback
+[You can contact us at here](https://www.hashmapinc.com/reach-out) if you want to learn more about Hashmap.
 
-### `npm test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `npm run build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify
+[You can also provide feedback on this tool at here](https://docs.google.com/forms/d/e/1FAIpQLSc6B82kzw1y9ZwxurukXdgKmQacKiTwof099IFGXE-7NSI77Q/viewform?usp=sf_link)

--- a/src/Components/CalcForm.js
+++ b/src/Components/CalcForm.js
@@ -71,10 +71,10 @@ class CalcForm extends Component {
       event.stopPropagation();
     }
 
-    /** starting credit calculation */
+    //============================================ 
+    // starting credit calculation
+    //============================================ 
     this.setState({isLoading:true});
-
-    // parse state
 
     // calculate ingestion usage
     const annual_ingestions = this.getAnnualOccurences(this.state.ingestion_frequency);
@@ -93,14 +93,15 @@ class CalcForm extends Component {
       this.state.transformation_complexity === "Low" ? 0.5 : 
       null;
     const data_processed_per_transformation = total_data_to_ingest / annual_transformations;
-    const credits_used_per_transformation = Math.max(
+    const credits_used_per_transformation = this.state.bi_dashboards == 0 ? 0 : Math.max( // if there are no dashboards, assume no transformation
       1/60, // minimum possible number of credits usable in snowflake
       data_processed_per_transformation / 1024 * 32 / 15.4 * Math.log10(this.state.bi_dashboards) * transformation_complexity_factor
     );
 
     // calculate consumption usage
     const annual_consumptions = Math.max(365, annual_transformations) * this.state.bi_dashboards;
-    const credits_used_per_consumption = 1/60 * Math.log2(this.state.data_growth_rate); // TODO: find a better way to do this. Currently assuming BI tables are properly designed for rapid consumption and that credit usage growths lograthmically with the amount of "recent" data. 
+    // TODO: find a better way to do this. Currently assuming BI tables are properly designed for rapid consumption and that credit usage growths lograthmically with the amount of "recent" data. 
+    const credits_used_per_consumption = this.state.bi_dashboards == 0 ? 0 : 1/60 * Math.log2(this.state.data_growth_rate); // if there are no dashboards, assume no consumption
 
     // calculate components of annual usage
     const ingestion_usage      = annual_ingestions * credits_used_per_ingestion;
@@ -109,6 +110,7 @@ class CalcForm extends Component {
 
     // calculate annual usage
     const annual_usage = ingestion_usage + transformation_usage + consumption_usage;
+    //============================================ 
 
     this.setState({
       low_calc_results:  0.5 * annual_usage,
@@ -135,11 +137,11 @@ class CalcForm extends Component {
         </div>
         <div className="row">
         <div className="col-8 col-xs-12 order-md-1 mx-auto">
-          <h4 className="mb-3 text-center bold">Anticipated Snowflake usage details:</h4>
+          <h4 className="mb-3 text-center bold">Anticipated Snowflake Usage Details:</h4>
         <div className='full_page'>
             <Form id='estimator-form' className="needs-validation" noValidate validated={validated} onSubmit={this.handleSubmit}>
                 <Form.Group md="4" controlId="data_size">
-                  <Form.Label>Total Data size before Snowflake compression<span className="text-muted"> (in gigabytes)</span></Form.Label>
+                  <Form.Label>Total data size before Snowflake compression<span className="text-muted"> (in gigabytes)</span></Form.Label>
                   <Form.Control
                     onChange={this.handleInputChange}
                     required

--- a/src/Components/CalcForm.js
+++ b/src/Components/CalcForm.js
@@ -93,7 +93,7 @@ class CalcForm extends Component {
       this.state.transformation_complexity === "Low" ? 0.5 : 
       null;
     const data_processed_per_transformation = total_data_to_ingest / annual_transformations;
-    const credits_used_per_transformation = this.state.bi_dashboards == 0 ? 0 : Math.max( // if there are no dashboards, assume no transformation
+    const credits_used_per_transformation = this.state.bi_dashboards === 0 ? 0 : Math.max( // if there are no dashboards, assume no transformation
       1/60, // minimum possible number of credits usable in snowflake
       data_processed_per_transformation / 1024 * 32 / 15.4 * Math.log10(this.state.bi_dashboards) * transformation_complexity_factor
     );
@@ -101,7 +101,7 @@ class CalcForm extends Component {
     // calculate consumption usage
     const annual_consumptions = Math.max(365, annual_transformations) * this.state.bi_dashboards;
     // TODO: find a better way to do this. Currently assuming BI tables are properly designed for rapid consumption and that credit usage growths lograthmically with the amount of "recent" data. 
-    const credits_used_per_consumption = this.state.bi_dashboards == 0 ? 0 : 1/60 * Math.log2(this.state.data_growth_rate); // if there are no dashboards, assume no consumption
+    const credits_used_per_consumption = this.state.bi_dashboards === 0 ? 0 : 1/60 * Math.log2(this.state.data_growth_rate); // if there are no dashboards, assume no consumption
 
     // calculate components of annual usage
     const ingestion_usage      = annual_ingestions * credits_used_per_ingestion;
@@ -128,86 +128,87 @@ class CalcForm extends Component {
     /** renders form */
     return (
       <Container fluid>
-        <div className="py-5 text-left">
+        <div className="row">
+          <div className="pt-5 col-8 col-xs-12 mx-auto">
+            <h4 className="mb-3 text-center bold">Anticipated Snowflake Usage Details:</h4>
+            <div className='full_page'>
+              <Form id='estimator-form' className="needs-validation" noValidate validated={validated} onSubmit={this.handleSubmit}>
+                    <Form.Group md="4" controlId="data_size">
+                      <Form.Label>Total data size before Snowflake compression<span className="text-muted"> (in gigabytes)</span></Form.Label>
+                      <Form.Control
+                        onChange={this.handleInputChange}
+                        required
+                        type="number"
+                        placeholder={this.state.data_size + ' Gigabytes'}
+                        name="data_size"
+                      />
+                      <Form.Control.Feedback type="invalid">Please enter your anticipated data size.</Form.Control.Feedback>
+                    </Form.Group>
+                    <Form.Group md="4" controlId="data_growth_rate">
+                      <Form.Label>Data growth rate<span className="text-muted"> (how much does data size increase every month in gigabytes)</span></Form.Label>
+                      <Form.Control
+                        onChange={this.handleInputChange}
+                        required
+                        type="number"
+                        placeholder={this.state.data_growth_rate + ' Gigabytes / month'}
+                        name="data_growth_rate"
+                      />
+                      <Form.Control.Feedback type="invalid">Please enter your expected monthly data growth in gigabytes.</Form.Control.Feedback>
+                    </Form.Group>
+                    <Form.Group md="4" controlId="ingestion_frequency">
+                      <Form.Label>Data ingestion frequency<span className="text-muted"> (on average, how often do you plan to ingest data)</span></Form.Label>
+                      <Form.Control as="select" name="ingestion_frequency" required onChange={this.handleInputChange} custom 
+                        defaultValue={this.state.ingestion_frequency}>
+                        <option>Every Minute</option>
+                        <option>Every Hour</option>
+                        <option>Every Day</option>
+                        <option>Every Week</option>
+                      </Form.Control>
+                    </Form.Group>
+                    <Form.Group md="4" controlId="bi_dashboards">
+                      <Form.Label>Number of BI dashboards<span className="text-muted"> (10 for small, 100 for medium, and 1000 for large organizations if you're not sure)</span></Form.Label>
+                      <Form.Control
+                        onChange={this.handleInputChange}
+                        required
+                        type="number"
+                        placeholder={this.state.bi_dashboards + ' Dashboards'}
+                        name="bi_dashboards"
+                      />
+                      <Form.Control.Feedback type="invalid">Please enter your expected number of BI dashboards.</Form.Control.Feedback>
+                    </Form.Group>
+                    <Form.Group md="4" controlId="transformation_complexity">
+                      <Form.Label>Typical transformation complexity <span className="text-muted"> (on average)</span></Form.Label>
+                      <Form.Control as="select" name="transformation_complexity" required onChange={this.handleInputChange} custom
+                        defaultValue={this.state.transformation_complexity}>
+                        <option>Low</option>
+                        <option>Medium</option>
+                        <option>High</option>
+                      </Form.Control>
+                    </Form.Group>
+                    <Form.Group md="4" controlId="transformation_frequency">
+                      <Form.Label>Data transformation frequency<span className="text-muted"> (on average, how often do you plan to process data)</span></Form.Label>
+                      <Form.Control as="select" name="transformation_frequency" required onChange={this.handleInputChange} custom
+                        defaultValue={this.state.transformation_frequency}>
+                        <option>Every Minute</option>
+                        <option>Every Hour</option>
+                        <option>Every Day</option>
+                        <option>Every Week</option>
+                      </Form.Control>
+                    </Form.Group>
+                  <Button variant="btn btn-primary btn-lg btn-block" type="submit" id="submit_button">Estimate Credits</Button>
+                </Form>
+            </div>
+          </div>
+
+          <div className="text-left">
             <p>Snowflake Estimator is designed to provide high-level estimates of Snowflake usage for those considering migration to a Modern Cloud Data Warehouse. </p>
             <p>This tool is not a replacement for a proper assessment! Please use it as a rough order of magnitude estimate for your credit consumption in Snowflake.</p>
             <p><a class='link' href='https://www.hashmapinc.com/snowflakeestimator-reachout'>If you're interested in a more formal exercise, please reach out!</a></p>
             <LoadingSpinner isLoading={isLoading}></LoadingSpinner>
             <Results low_calc_results={low_calc_results} med_calc_results={med_calc_results} high_calc_results={high_calc_results} handler={this.handleResultClick}></Results>
-        </div>
-        <div className="row">
-        <div className="col-8 col-xs-12 order-md-1 mx-auto">
-          <h4 className="mb-3 text-center bold">Anticipated Snowflake Usage Details:</h4>
-        <div className='full_page'>
-            <Form id='estimator-form' className="needs-validation" noValidate validated={validated} onSubmit={this.handleSubmit}>
-                <Form.Group md="4" controlId="data_size">
-                  <Form.Label>Total data size before Snowflake compression<span className="text-muted"> (in gigabytes)</span></Form.Label>
-                  <Form.Control
-                    onChange={this.handleInputChange}
-                    required
-                    type="number"
-                    placeholder={this.state.data_size + ' Gigabytes'}
-                    name="data_size"
-                  />
-                  <Form.Control.Feedback type="invalid">Please enter your anticipated data size.</Form.Control.Feedback>
-                </Form.Group>
-                <Form.Group md="4" controlId="data_growth_rate">
-                  <Form.Label>Data growth rate<span className="text-muted"> (how much does data size increase every month in gigabytes)</span></Form.Label>
-                  <Form.Control
-                    onChange={this.handleInputChange}
-                    required
-                    type="number"
-                    placeholder={this.state.data_growth_rate + ' Gigabytes / month'}
-                    name="data_growth_rate"
-                  />
-                  <Form.Control.Feedback type="invalid">Please enter your expected monthly data growth in gigabytes.</Form.Control.Feedback>
-                </Form.Group>
-                <Form.Group md="4" controlId="ingestion_frequency">
-                  <Form.Label>Data ingestion frequency<span className="text-muted"> (on average, how often do you plan to ingest data)</span></Form.Label>
-                  <Form.Control as="select" name="ingestion_frequency" required onChange={this.handleInputChange} custom 
-                    defaultValue={this.state.ingestion_frequency}>
-                    <option>Every Minute</option>
-                    <option>Every Hour</option>
-                    <option>Every Day</option>
-                    <option>Every Week</option>
-                  </Form.Control>
-                </Form.Group>
-                <Form.Group md="4" controlId="bi_dashboards">
-                  <Form.Label>Number of BI dashboards<span className="text-muted"> (10 for small, 100 for medium, and 1000 for large organizations if you're not sure)</span></Form.Label>
-                  <Form.Control
-                    onChange={this.handleInputChange}
-                    required
-                    type="number"
-                    placeholder={this.state.bi_dashboards + ' Dashboards'}
-                    name="bi_dashboards"
-                  />
-                  <Form.Control.Feedback type="invalid">Please enter your expected number of BI dashboards.</Form.Control.Feedback>
-                </Form.Group>
-                <Form.Group md="4" controlId="transformation_complexity">
-                  <Form.Label>Typical transformation complexity <span className="text-muted"> (on average)</span></Form.Label>
-                  <Form.Control as="select" name="transformation_complexity" required onChange={this.handleInputChange} custom
-                    defaultValue={this.state.transformation_complexity}>
-                    <option>Low</option>
-                    <option>Medium</option>
-                    <option>High</option>
-                  </Form.Control>
-                </Form.Group>
-                <Form.Group md="4" controlId="transformation_frequency">
-                  <Form.Label>Data transformation frequency<span className="text-muted"> (on average, how often do you plan to process data)</span></Form.Label>
-                  <Form.Control as="select" name="transformation_frequency" required onChange={this.handleInputChange} custom
-                    defaultValue={this.state.transformation_frequency}>
-                    <option>Every Minute</option>
-                    <option>Every Hour</option>
-                    <option>Every Day</option>
-                    <option>Every Week</option>
-                  </Form.Control>
-                </Form.Group>
-              <Button variant="btn btn-primary btn-lg btn-block" type="submit" id="submit_button">Estimate Credits</Button>
-            </Form>
           </div>
         </div>
-      </div>
-    </Container>
+      </Container>
     )
   }
 }

--- a/src/Components/CalcResults.js
+++ b/src/Components/CalcResults.js
@@ -4,22 +4,23 @@ import LineChart from "./LineChart.js"
 import '../main.css';
 
 class Results extends React.Component {
-    render() {
-        if (this.props.med_calc_results) {
-              return <Container fluid id="overlay" className="w-100 h-100">
-                          <div id="overlay_content" className="position-relative col-lg-10 order-sm-1 mx-auto">
-                                <h1 className="credits">We estimate an average credit usage rate of about {(12*Math.round(this.props.med_calc_results/12)).toLocaleString()} credits annually or {Math.round(this.props.med_calc_results/12).toLocaleString()} credits every month.</h1>
-                                <Button id='newCalcButton' variant="btn btn-primary btn-lg" type="submit" className="overlay_button" onClick={this.props.handler}>Make Another Calculation</Button>
-                                <LineChart className="row-sm"low_calc_results={this.props.low_calc_results} med_calc_results={this.props.med_calc_results} high_calc_results={this.props.high_calc_results}/>             
-                          </div>
-                     </Container>
-
-        }
-        else {
-            return <div></div>
-        }
-        
-              }
-    }
+  render() {
+      if (this.props.med_calc_results) {
+        return (
+          <Container fluid id="overlay" className="w-100 h-100">
+            <div id="overlay_content" className="position-relative col-lg-10 order-sm-1 mx-auto">
+              <h1 className="credits">{(12*Math.round(this.props.med_calc_results/12)).toLocaleString()}</h1>
+              <p>Estimated Annual Credit Usage</p>
+              <LineChart className="row-sm"low_calc_results={this.props.low_calc_results} med_calc_results={this.props.med_calc_results} high_calc_results={this.props.high_calc_results}/>   
+              <Button id='newCalcButton' variant="btn btn-primary btn-lg" type="submit" className="overlay_button" onClick={this.props.handler}>Make Another Calculation</Button>          
+            </div>
+          </Container>
+        );
+      }
+      else {
+        return (<div></div>);
+      }
+  }
+}
 
 export default Results;

--- a/src/Components/LineChart.js
+++ b/src/Components/LineChart.js
@@ -24,9 +24,9 @@ class LineChart extends React.Component {
             var med_total = 0;
             var high_total = 0;
 
-            var low_monthly_credits = this.props.low_calc_results/12;
-            var med_monthly_credits = this.props.med_calc_results/12;
-            var high_monthly_credits = this.props.high_calc_results/12;
+            var low_monthly_credits  = Math.round(this.props.low_calc_results/12);
+            var med_monthly_credits  = Math.round(this.props.med_calc_results/12);
+            var high_monthly_credits = Math.round(this.props.high_calc_results/12);
 
             for (i = 0; i < 12; i++) {
               low_est.push(low_monthly_credits+low_total)

--- a/src/Components/LineChart.js
+++ b/src/Components/LineChart.js
@@ -24,9 +24,10 @@ class LineChart extends React.Component {
             var med_total = 0;
             var high_total = 0;
 
-            var low_monthly_credits  = Math.round(this.props.low_calc_results/12);
-            var med_monthly_credits  = Math.round(this.props.med_calc_results/12);
-            var high_monthly_credits = Math.round(this.props.high_calc_results/12);
+            // use 1 credit a month minimum, round to an even 1/12th integer multiple value of the total annual usage
+            var low_monthly_credits  = Math.max(1, Math.round(this.props.low_calc_results/12));
+            var med_monthly_credits  = Math.max(1, Math.round(this.props.med_calc_results/12));
+            var high_monthly_credits = Math.max(1, Math.round(this.props.high_calc_results/12));
 
             for (i = 0; i < 12; i++) {
               low_est.push(low_monthly_credits+low_total)

--- a/src/main.css
+++ b/src/main.css
@@ -70,7 +70,7 @@ body {
   height: 80vh;
   overflow: auto;
   margin-top: 100px;
-  background-color: #f8f4f4;
+  background-color: #ffffff;
   border-radius: 10px;
   text-align: center;
   z-index: 11; /* 1px higher than the overlay layer */


### PR DESCRIPTION
This PR includes:
- readme content
- UI rearrangement and updates to display better
- update to usage calculations to remove decimals and to allow for the input of 0 BI dashboards. When dashboards are 0 then all transformation and bi consumption is also assumed to be 0 - effectively making this an ingestion cost estimate.

This resolves #3 and #4 